### PR TITLE
try to write 2 significant digits for doubles instead of always truncating to 2 digits after the decimal point

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
+
 # svglite (development version)
+
+* Dimensions smaller than 1 now retain two significant figures (#94, @ilia-kats).
 
 
 # svglite 1.2.2

--- a/src/SvgStream.h
+++ b/src/SvgStream.h
@@ -11,7 +11,7 @@ namespace svglite { namespace internal {
 template <typename T>
 void write_double(T& stream, double data) {
   std::streamsize prec = stream.precision();
-  uint8_t newprec = std::fabs(data) >= 1 ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
+  uint8_t newprec = std::fabs(data) >= 1 || data == 0. ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
   stream << std::setprecision(newprec) << data << std::setprecision(prec);
 }
 

--- a/src/SvgStream.h
+++ b/src/SvgStream.h
@@ -6,6 +6,18 @@
 #include <Rcpp.h>
 #include "utils.h"
 
+namespace svglite { namespace internal {
+
+template <typename T>
+void write_double(T& stream, double data) {
+  std::streamsize prec = stream.precision();
+  uint8_t newprec = std::fabs(data) >= 1 ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
+  stream << std::setprecision(newprec) << data << std::setprecision(prec);
+}
+
+}} // namespace svglite::internal
+
+
 class SvgStream {
   public:
 
@@ -52,11 +64,7 @@ public:
   }
 
   void write(int data)            { stream_ << data; }
-  void write(double data) {
-    std::streamsize prec = stream_.precision();
-    uint8_t newprec = std::fabs(data) >= 1 ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
-    stream_ << std::setprecision(newprec) << data << std::setprecision(prec);
-  }
+  void write(double data)         { svglite::internal::write_double(stream_, data); }
   void write(const char* data)    { stream_ << data; }
   void write(char data)           { stream_ << data; }
   void write(const std::string& data) { stream_ << data; }
@@ -92,11 +100,7 @@ public:
   }
 
   void write(int data)                { stream_ << data; }
-  void write(double data) {
-      std::streamsize prec = stream_.precision();
-      uint8_t newprec = std::fabs(data) >= 1 ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
-      stream_ << std::setprecision(newprec) << data << std::setprecision(prec);
-  }
+  void write(double data)             { svglite::internal::write_double(stream_, data); }
   void write(const char* data)        { stream_ << data; }
   void write(char data)               { stream_ << data; }
   void write(const std::string& data) { stream_ << data; }

--- a/src/SvgStream.h
+++ b/src/SvgStream.h
@@ -52,7 +52,11 @@ public:
   }
 
   void write(int data)            { stream_ << data; }
-  void write(double data)         { stream_ << data; }
+  void write(double data) {
+    std::streamsize prec = stream_.precision();
+    uint8_t newprec = std::fabs(data) >= 1 ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
+    stream_ << std::setprecision(newprec) << data << std::setprecision(prec);
+  }
   void write(const char* data)    { stream_ << data; }
   void write(char data)           { stream_ << data; }
   void write(const std::string& data) { stream_ << data; }
@@ -88,7 +92,11 @@ public:
   }
 
   void write(int data)                { stream_ << data; }
-  void write(double data)             { stream_ << data; }
+  void write(double data) {
+      std::streamsize prec = stream_.precision();
+      uint8_t newprec = std::fabs(data) >= 1 ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
+      stream_ << std::setprecision(newprec) << data << std::setprecision(prec);
+  }
   void write(const char* data)        { stream_ << data; }
   void write(char data)               { stream_ << data; }
   void write(const std::string& data) { stream_ << data; }

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,10 +1,11 @@
 #ifndef __UTILS__
 #define __UTILS__
 
+#include <limits>
 #include <cmath>
 
 double dbl_format(double x) {
-  if (std::abs(x) < 0.01)
+  if (std::abs(x) < std::numeric_limits<double>::epsilon())
     return 0.00;
   else
     return x;

--- a/tests/testthat/test-scale-text.svg
+++ b/tests/testthat/test-scale-text.svg
@@ -12,6 +12,6 @@
   ]]></style>
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
-<rect x='0.00' y='0.00' width='34.03' height='8.70' style='stroke-width: 0.75; stroke: #FF0000; fill: #FFFFFF;' />
-<text x='0.00' y='8.26' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='34.03px' lengthAdjust='spacingAndGlyphs'>foobar</text>
+<rect x='0' y='0.0000000000000018' width='34.03' height='8.70' style='stroke-width: 0.75; stroke: #FF0000; fill: #FFFFFF;' />
+<text x='0' y='8.26' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='34.03px' lengthAdjust='spacingAndGlyphs'>foobar</text>
 </svg>

--- a/tests/testthat/test-scale-text.svg
+++ b/tests/testthat/test-scale-text.svg
@@ -12,6 +12,6 @@
   ]]></style>
 </defs>
 <rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
-<rect x='0' y='0.0000000000000018' width='34.03' height='8.70' style='stroke-width: 0.75; stroke: #FF0000; fill: #FFFFFF;' />
-<text x='0' y='8.26' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='34.03px' lengthAdjust='spacingAndGlyphs'>foobar</text>
+<rect x='0.00' y='0.0000000000000018' width='34.03' height='8.70' style='stroke-width: 0.75; stroke: #FF0000; fill: #FFFFFF;' />
+<text x='0.00' y='8.26' style='font-size: 12.00px; font-family: Liberation Sans;' textLength='34.03px' lengthAdjust='spacingAndGlyphs'>foobar</text>
 </svg>


### PR DESCRIPTION
The current behavior of svglite is a problem e.g. when using heatmap.2 from gplots. If enough break points are used (in my case, 100 was sufficient), the width of the individual rectangles in the color key becomes smaller than 0.01, which results in svglite truncating it to 0 and no color key being drawn. This patch attempts to fix that by ensuring that the writing precision for doubles is set such that the two significant digits are written.