### PR TITLE
Renamed parameter from 'file' to 'filename'. Enables use with ggsave().

### DIFF
--- a/R/SVG.R
+++ b/R/SVG.R
@@ -13,7 +13,7 @@
 #' used to create the svg, and the computer used to render the
 #' svg. See the \code{fonts} vignette for more information.
 #'
-#' @param file The file where output will appear.
+#' @param filename The file where output will appear.
 #' @param height,width Height and width in inches.
 #' @param bg Default background color for the plot (defaults to "white").
 #' @param pointsize Default point size.
@@ -60,11 +60,11 @@
 #' @importFrom Rcpp sourceCpp
 #' @importFrom gdtools raster_view
 #' @export
-svglite <- function(file = "Rplots.svg", width = 10, height = 8,
+svglite <- function(filename = "Rplots.svg", width = 10, height = 8,
                     bg = "white", pointsize = 12, standalone = TRUE,
                     system_fonts = list(), user_fonts = list()) {
   aliases <- validate_aliases(system_fonts, user_fonts)
-  invisible(svglite_(file, bg, width, height, pointsize, standalone, aliases))
+  invisible(svglite_(filename, bg, width, height, pointsize, standalone, aliases))
 }
 
 #' Access current SVG as a string.


### PR DESCRIPTION
Hi!

I've been battling with SVG output from R all day, frustrated by the fact that text is converted to paths. So I was thrilled to discover `{svglite}`. Thank you.

Here's a small contribution, changing the name of the first parameter to `svglite()` to enable it to be used with `ggsave()`. Here's an example:

```
library(svglite)
library(ggplot2)

ggplot(iris, aes(x = Sepal.Length)) + geom_histogram()

ggsave("iris.svg", device = svglite)
```

I ran the test suite and this did not have any adverse effects. And, on the contrary, it means that I can very easily now use it in my existing scripts which all use `ggsave()`.

Thanks,
Andrew.