### PR TITLE
circle radius no longer specified in points

### DIFF
--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -545,7 +545,7 @@ void svg_circle(double x, double y, double r, const pGEcontext gc,
   SVGDesc *svgd = (SVGDesc*) dd->deviceSpecific;
   SvgStreamPtr stream = svgd->stream;
 
-  (*stream) << "<circle cx='" << x << "' cy='" << y << "' r='" << r << "pt'";
+  (*stream) << "<circle cx='" << x << "' cy='" << y << "' r='" << r << "'";
 
   write_style_begin(stream);
   write_style_linetype(stream, gc, true);

--- a/tests/testthat/test-points.R
+++ b/tests/testthat/test-points.R
@@ -1,14 +1,14 @@
 context("Points")
 library(xml2)
 
-test_that("radius is given in points", {
+test_that("radius is not given in points", {
   x <- xmlSVG({
     plot.new()
     points(0.5, 0.5, cex = 20)
     text(0.5, 0.5, cex = 20)
   })
   circle <- xml_find_all(x, ".//circle")
-  expect_equal(xml_attr(circle, "r"), "54.00pt")
+  expect_equal(xml_attr(circle, "r"), "54.00")
 })
 
 test_that("points are given stroke and fill", {


### PR DESCRIPTION
Fixes #93 

Example of the differences this pr introduces:
```r
library("grid")

draw_hidden_circle <- function() {
  pushViewport(viewport(width=0.5, height=0.5))
  grid.circle(gp=gpar(fill="blue"))
  grid.rect(gp=gpar(fill="yellow"))
  popViewport()
}

# svglite::svglite("svglite_test_pr.svg", width = 7, height = 7); draw_hidden_circle(); dev.off()
svglite::svglite("svglite_test_master.svg", width = 7, height = 7); draw_hidden_circle(); dev.off()
```
left master, right this pr:

![image](https://user-images.githubusercontent.com/21319932/72146199-41330980-339c-11ea-9ecd-8d12a1aa3732.png)

There was a unit test that specifically checked if the radius of a circle was specified in points, so perhaps was an (undocumented) reason for this? If preferred I can also create some way to switch between points/ no points behavior (e.g., using an environment variable or just a boolean argument).

Comments are welcome!

