### PR TITLE
Make sure the svg records absolute size

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # svglite (development version)
 
+* Dimensions are now encoded into the top-level `<svg>` tag (#90)
+
 # svglite 1.2.3
 
 * The radius of circles is no longer expressed in pt (#93, @vandenman).

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -372,7 +372,7 @@ BEGIN_RCPP
     //http://www.w3.org/wiki/SVG_Links
     (*stream) << " xmlns:xlink='http://www.w3.org/1999/xlink'";
   }
-
+  (*stream) << " width='" << dd->right << "pt' height='" << dd->bottom << "pt'";
   (*stream) << " viewBox='0 0 " << dd->right << ' ' << dd->bottom << "'>\n";
 
   // Initialise clipping the same way R does


### PR DESCRIPTION
Fix #90 width and height were not set on the svg tag resulting in dimensions not being calculated correctly