### PR TITLE
Do not use external_pointer class in function signatures

### DIFF
--- a/R/cpp11-exports.R
+++ b/R/cpp11-exports.R
@@ -8,8 +8,8 @@ svgstring_ <- function(env, bg, width, height, pointsize, standalone, aliases, i
   .Call("_svglite_svgstring_" , env, bg, width, height, pointsize, standalone, aliases, id)
 }
 
-get_svg_content <- function(p){
-  .Call("_svglite_get_svg_content" , p)
+get_svg_content <- function(p_sxp){
+  .Call("_svglite_get_svg_content" , p_sxp)
 }
 
 

--- a/src/cpp11-exports.cpp
+++ b/src/cpp11-exports.cpp
@@ -11,17 +11,17 @@ extern "C" SEXP _svglite_svglite_(SEXP file, SEXP bg, SEXP width, SEXP height, S
   END_CPP11
 }
 // devSVG.cpp
-cpp11::external_pointer<std::stringstream> svgstring_(cpp11::environment env, std::string bg, double width, double height, double pointsize, bool standalone, cpp11::list aliases, cpp11::strings id);
+SEXP svgstring_(cpp11::environment env, std::string bg, double width, double height, double pointsize, bool standalone, cpp11::list aliases, cpp11::strings id);
 extern "C" SEXP _svglite_svgstring_(SEXP env, SEXP bg, SEXP width, SEXP height, SEXP pointsize, SEXP standalone, SEXP aliases, SEXP id) {
   BEGIN_CPP11
     return cpp11::as_sexp(svgstring_(cpp11::unmove(cpp11::as_cpp<cpp11::environment>(env)), cpp11::unmove(cpp11::as_cpp<std::string>(bg)), cpp11::unmove(cpp11::as_cpp<double>(width)), cpp11::unmove(cpp11::as_cpp<double>(height)), cpp11::unmove(cpp11::as_cpp<double>(pointsize)), cpp11::unmove(cpp11::as_cpp<bool>(standalone)), cpp11::unmove(cpp11::as_cpp<cpp11::list>(aliases)), cpp11::unmove(cpp11::as_cpp<cpp11::strings>(id))));
   END_CPP11
 }
 // devSVG.cpp
-std::string get_svg_content(cpp11::external_pointer<std::stringstream> p);
-extern "C" SEXP _svglite_get_svg_content(SEXP p) {
+std::string get_svg_content(SEXP p_sxp);
+extern "C" SEXP _svglite_get_svg_content(SEXP p_sxp) {
   BEGIN_CPP11
-    return cpp11::as_sexp(get_svg_content(cpp11::unmove(cpp11::as_cpp<cpp11::external_pointer<std::stringstream>>(p))));
+    return cpp11::as_sexp(get_svg_content(cpp11::unmove(cpp11::as_cpp<SEXP>(p_sxp))));
   END_CPP11
 }
 

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -935,7 +935,7 @@ bool svglite_(std::string file, std::string bg, double width, double height,
 }
 
 [[cpp11::export]]
-cpp11::external_pointer<std::stringstream> svgstring_(cpp11::environment env, std::string bg,
+SEXP svgstring_(cpp11::environment env, std::string bg,
                                          double width, double height, double pointsize,
                                          bool standalone, cpp11::list aliases,
                                          cpp11::strings id) {
@@ -945,11 +945,13 @@ cpp11::external_pointer<std::stringstream> svgstring_(cpp11::environment env, st
 
   SvgStreamString* strstream = static_cast<SvgStreamString*>(stream.get());
 
-  return {strstream->string_src()};
+  cpp11::external_pointer<std::stringstream> out(strstream->string_src());
+  return cpp11::as_sexp(out);
 }
 
 [[cpp11::export]]
-std::string get_svg_content(cpp11::external_pointer<std::stringstream> p) {
+std::string get_svg_content(SEXP p_sxp) {
+  cpp11::external_pointer<std::stringstream> p(p_sxp);
   p->flush();
   std::string svgstr = p->str();
   // If the current SVG is empty, we also make the string empty


### PR DESCRIPTION
The external pointer is around a `std::stringstream` and
that header won't be included automatically in cpp11-exports.cpp.

I think the best way forward s to avoid putting that class in the exported function signature. This requires you to do the conversions within the function, but that seems only a minor inconvenience.