### PR TITLE
Prefer .empty() to nominally equivalent .size() checks

### DIFF
--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -296,11 +296,11 @@ inline std::string fontname(const char* family_, int face,
     family = "sans";
 
   std::string alias = find_system_alias(family, system_aliases);
-  if (!alias.size()) {
+  if (alias.empty()) {
     alias = find_user_alias(family, user_aliases, face, "name");
   }
 
-  if (alias.size()) {
+  if (!alias.empty()) {
     return alias;
   }
 
@@ -332,7 +332,7 @@ inline FontSettings get_font_file(const char* family, int face, cpp11::list user
     fontfamily = "sans";
   }
   std::string alias = fontfile(fontfamily, face, user_aliases);
-  if (alias.size() > 0) {
+  if (!alias.empty()) {
     FontSettings result = {};
     std::strncpy(result.file, alias.c_str(), PATH_MAX);
     result.index = 0;
@@ -528,7 +528,7 @@ inline void write_style_linetype(SvgStreamPtr stream, const pGEcontext gc, doubl
 }
 
 std::string get_id(SVGDesc *svgd) {
-  if (svgd->ids.size() == 0) {
+  if (svgd->ids.empty()) {
     return "";
   }
   if (svgd->ids.size() == 1) {
@@ -645,7 +645,7 @@ void svg_new_page(const pGEcontext gc, pDevDesc dd) {
     (*stream) << " xmlns:xlink='http://www.w3.org/1999/xlink'";
   }
 
-  if (id.size() > 0)
+  if (!id.empty())
     (*stream) << " id='" << id << "'";
 
   (*stream) << " class='svglite'";

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -364,7 +364,7 @@ inline void write_attr_str(SvgStreamPtr stream, const char* attr, const char* va
 
 // Writing clip path attribute
 inline void write_attr_clip(SvgStreamPtr stream, std::string clipid) {
-  if (!clipid.size())
+  if (clipid.empty())
     return;
 
   (*stream) << " clip-path='url(#cp" << clipid << ")'";


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/readability-container-size-empty.html