### PR TITLE
feat: Also auto compress filenames ending in ".gz"

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -74,7 +74,7 @@ fs::file_size(tmp1)
 fs::file_size(tmp2)
 ```
 
-In both cases, compressing to make `.svgz` (gzipped svg) is worthwhile. svglite supports compressed output directly which will be triggered if the provided path has a `".svgz"` extension.
+In both cases, compressing to make `.svgz` (gzipped svg) is worthwhile. svglite supports compressed output directly which will be triggered if the provided path has a `".svgz"` (or `".svg.gz"`) extension.
 
 ```{r}
 tmp3 <- tempfile(fileext = ".svgz")

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ fs::file_size(tmp2)
 
 In both cases, compressing to make `.svgz` (gzipped svg) is worthwhile.
 svglite supports compressed output directly which will be triggered if
-the provided path has a `".svgz"` extension.
+the provided path has a `".svgz"` (or `".svg.gz"`) extension.
 
 ``` r
 tmp3 <- tempfile(fileext = ".svgz")

--- a/src/SvgStream.h
+++ b/src/SvgStream.h
@@ -83,7 +83,8 @@ class SvgStreamFile : public SvgStream {
 public:
   SvgStreamFile(const std::string& path, bool _always_valid = false) : always_valid(_always_valid) {
     std::string svgz_ext = path.size() > 5 ? path.substr(path.size() - 5) : "";
-    compress = iequals(svgz_ext, ".svgz");
+    std::string gz_ext = path.size() > 3 ? path.substr(path.size() - 3) : "";
+    compress = iequals(svgz_ext, ".svgz") || iequals(gz_ext, ".gz");
     file = R_ExpandFileName(path.c_str());
 
     stream_.open(file.c_str());
@@ -96,7 +97,8 @@ public:
 
   SvgStreamFile(const std::string& path, int pageno, bool _always_valid = false) : always_valid(_always_valid) {
     std::string svgz_ext = path.size() > 5 ? path.substr(path.size() - 5) : "";
-    compress = iequals(svgz_ext, ".svgz");
+    std::string gz_ext = path.size() > 3 ? path.substr(path.size() - 3) : "";
+    compress = iequals(svgz_ext, ".svgz") || iequals(gz_ext, ".gz");
 
     char buf[PATH_MAX+1];
     snprintf(buf, PATH_MAX, path.c_str(), pageno);


### PR DESCRIPTION
* Now also auto compress filenames ending in ".gz" (the standard filename extension to indicate gzip compression) in addition to ".svgz"
* In particular some users prefer ".svg.gz" over ".svgz"

follow up on #162