### PR TITLE
Change type of newprec from uint8_t to int

### DIFF
--- a/src/SvgStream.h
+++ b/src/SvgStream.h
@@ -18,7 +18,7 @@ namespace svglite { namespace internal {
 template <typename T>
 void write_double(T& stream, double data) {
   std::streamsize prec = stream.precision();
-  uint8_t newprec = std::fabs(data) >= 1 || data == 0. ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
+  int newprec = std::fabs(data) >= 1 || data == 0. ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;
   stream << std::setprecision(newprec) << data << std::setprecision(prec);
 }
 


### PR DESCRIPTION
Our production environment compiles packages with a bundle of sanitizers.  And we got the following error

```
SUMMARY: UndefinedBehaviorSanitizer: float-cast-overflow ../svglite/src/SvgStream.h:21:21  
```

Gemini suggested this change. And here is the Gemini output.


```
Okay, I see the issue. The runtime error float-cast-overflow is happening in the write_double function in SvgStream.h.

Specifically, this line is the problem:

uint8_t newprec = std::fabs(data) >= 1 || data == 0. ? prec : std::ceil(-std::log10(std::fabs(data))) + 1;

When the absolute value of data is very small (e.g., close to zero, like 1e-300), -std::log10(std::fabs(data)) becomes a large positive number. Adding 1 to it can result in a value greater than 255. Since newprec is declared as uint8_t, this large value overflows the representable range of uint8_t, causing the float-cast-overflow error.

The fix is to change the type of newprec to something that can hold larger values, such as int. The std::setprecision function accepts an int argument, so this change is safe.

I changed the type of newprec from uint8_t to int to prevent the overflow when calculating the precision for very small double values
```
